### PR TITLE
Make it possible for rproxy to stop advertising itself.

### DIFF
--- a/src/rproxy/__init__.py
+++ b/src/rproxy/__init__.py
@@ -59,10 +59,11 @@ class RProxyResource(Resource):
 
     isLeaf = True
 
-    def __init__(self, hosts, clacks, pool, reactor):
+    def __init__(self, hosts, clacks, pool, reactor, anonymous):
         self._clacks = clacks
         self._hosts = hosts
         self._agent = Agent(reactor, pool=pool)
+        self._anonymous = anonymous
 
     def render(self, request):
 
@@ -110,8 +111,9 @@ class RProxyResource(Resource):
 
             request.code = res.code
             request.responseHeaders = res.headers
-            request.responseHeaders.addRawHeader("X-Proxied-By",
-                                                 __version__.package + " " + __version__.base())
+            if not self.anonymous:
+                request.responseHeaders.addRawHeader("X-Proxied-By",
+                                                     __version__.package + " " + __version__.base())
 
             if request.isSecure() and host["sendhsts"]:
                 request.responseHeaders.setRawHeaders("Strict-Transport-Security",


### PR DESCRIPTION
It's frankly none of the client's business whether I'm using rproxy or not. I'd like to be able to switch this off. =)
