### PR TITLE
fix configuration key for certificates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Make a ``rproxy.ini``:
 .. code::
 
     [rproxy]
-    certificates=./my-certs
+    certificates=my-certs
     http_ports=80
     https_ports=443
 

--- a/README.rst
+++ b/README.rst
@@ -12,12 +12,18 @@ Install from PyPI:
 
     $ pip install rproxy
 
+Make a directory to store your certificates:
+
+.. code::
+
+    $ mkdir my-certs
+
 Make a ``rproxy.ini``:
 
 .. code::
 
     [rproxy]
-    certs=certificates
+    certificates=./my-certs
     http_ports=80
     https_ports=443
 


### PR DESCRIPTION
With the previously documented configuration, the server would silently start up without listening for https, because the "certificates" key wasn't found.  This explains more clearly that it should be the name of a directory, and uses the correct configuration key name.
