### PR TITLE
Add Python 3 support

### DIFF
--- a/src/rproxy/__init__.py
+++ b/src/rproxy/__init__.py
@@ -2,12 +2,12 @@
 
 from __future__ import absolute_import, division
 
-import ConfigParser
+from six.moves import configparser
 
 from zope.interface import implementer
 
-from urllib import urlencode
-from urlparse import urlparse
+from six.moves.urllib.parse import urlencode
+import six.moves.urllib.parse as urlparse
 
 from twisted.python.url import URL
 
@@ -245,7 +245,7 @@ class Options(usage.Options):
 
 def makeService(config):
 
-    ini = ConfigParser.RawConfigParser()
+    ini = configparser.RawConfigParser()
     ini.read(config['config'])
 
     configPath = FilePath(config['config']).parent()

--- a/src/rproxy/__init__.py
+++ b/src/rproxy/__init__.py
@@ -6,8 +6,7 @@ from six.moves import configparser
 
 from zope.interface import implementer
 
-from six.moves.urllib.parse import urlencode
-import six.moves.urllib.parse as urlparse
+from six.moves.urllib.parse import urlencode, urlparse
 
 from twisted.python.url import URL
 


### PR DESCRIPTION
Imports `configparser` and `urllib.parse` from `six` so works in Python 2 or Python 3.